### PR TITLE
feat: support customLinkHref when load default them link file like use absolute path.

### DIFF
--- a/src/apply/presetModeApply.js
+++ b/src/apply/presetModeApply.js
@@ -15,9 +15,9 @@ function getThemeExtractLinkTag({ publicPath, userOptions }) {
     tagName: 'link',
     voidTag: true,
     attributes: {
-      href: `/${publicPath || ''}/${
+      href: userOptions.customLinkHref(`/${publicPath || ''}/${
         userOptions.outputDir || ''
-      }/${filename}.css`.replace(/\/+(?=\/)/g, ''),
+      }/${filename}.css`.replace(/\/+(?=\/)/g, '')),
       rel: 'stylesheet',
       id: userOptions.themeLinkTagId,
     },

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ class ThemeCssExtractWebpackPlugin {
         includeStyleWithColors: [],
         hueDiffControls: { low: 0, high: 0 },
         customThemeOutputPath: '',
+        customLinkHref: (href) => href
       },
       options
     );

--- a/src/plugin-options.json
+++ b/src/plugin-options.json
@@ -61,6 +61,10 @@
     "customThemeOutputPath": {
       "description": "(https://github.com/GitOfZGT/theme-css-extract-webpack-plugin#customThemeOutputPath).",
       "type": "string"
+    },
+    "customLinkHref": {
+      "description": "(https://github.com/GitOfZGT/theme-css-extract-webpack-plugin#customLinkHref).",
+      "instanceof": "Function"
     }
   }
 }


### PR DESCRIPTION
Request static assets is not working when i pass a absolute cdn path，this change support custom link href when setting default theme.css file href path.